### PR TITLE
fix GRUB_DISABLE_SUBMENU check to be standard

### DIFF
--- a/scripts/10_antergos
+++ b/scripts/10_antergos
@@ -279,7 +279,7 @@ while [ "x$list" != "x" ] ; do
     linux_root_device_thisversion=${GRUB_DEVICE}
   fi
 
-  if [ "x$is_top_level" = xtrue ] && [ "x${GRUB_DISABLE_SUBMENU}" != xtrue ]; then
+  if [ "x$is_top_level" = xtrue ] && [ "x${GRUB_DISABLE_SUBMENU}" != xy ]; then
     linux_entry "${OS}" "${version}" simple \
     "${GRUB_CMDLINE_LINUX} ${GRUB_CMDLINE_LINUX_DEFAULT}"
 


### PR DESCRIPTION
The GRUB_DISABLE_SUBMENU should test against the value "y" as described here: https://wiki.archlinux.org/index.php/GRUB/Tips_and_tricks#Disable_submenu
The commit SHA: c7c106a525d9a65214d1a2f769e794e239319826 broke this by testing against "true". This commit fixes that and returns 10_antergos to the standard, documented, behavior as I reported in Antergos/Cnchi#500
